### PR TITLE
fix seal and unseal of nested and recursive structures, strings (char slices)

### DIFF
--- a/src/seal.zig
+++ b/src/seal.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const trait = std.meta.trait;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const AllocatorError = std.mem.Allocator.Error;
@@ -100,8 +99,8 @@ pub fn seal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!void
                 inline for (u.fields) |field| {
                     // Compare name to find variant in field list
                     if (std.mem.eql(u8, @tagName(ptr.*), field.name)) {
-                        const variantPtr: *field.type = undefined;
-                        try seal(@TypeOf(variantPtr), variantPtr, offset, size);
+                        const variant_ptr: *field.type = @constCast(&@field(ptr.*, field.name));
+                        try seal(@TypeOf(variant_ptr), variant_ptr, offset, size);
                     }
                 }
             }
@@ -112,7 +111,7 @@ pub fn seal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!void
                 if (ptr.* != null) {
                     // I'm not sure about this- can we use a pointer to the inner part of an optional
                     // even if that optional is not a pointer?
-                    try seal(*o.child, @as(*o.child, @ptrCast(&ptr.*.?)), offset, size);
+                    try seal(*o.child, @as(*o.child, @constCast(@ptrCast(&ptr.*.?))), offset, size);
                 }
             }
         },
@@ -247,8 +246,8 @@ pub fn unseal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!vo
                 inline for (u.fields) |field| {
                     // Compare name to find variant in field list
                     if (std.mem.eql(u8, @tagName(ptr.*), field.name)) {
-                        const variantPtr: *field.type = undefined;
-                        try unseal(@TypeOf(variantPtr), variantPtr, offset, size);
+                        const variant_ptr: *field.type = @constCast(&@field(ptr.*, field.name));
+                        try unseal(@TypeOf(variant_ptr), variant_ptr, offset, size);
                     }
                 }
             }
@@ -259,7 +258,7 @@ pub fn unseal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!vo
                 if (ptr.* != null) {
                     // I'm not sure about this- can we use a pointer to the inner part of an optional
                     // even if that optional is not a pointer?
-                    try unseal(*o.child, @as(*o.child, @ptrCast(&ptr.*.?)), offset, size);
+                    try unseal(*o.child, @as(*o.child, @constCast(@ptrCast(&ptr.*.?))), offset, size);
                 }
             }
         },
@@ -367,4 +366,300 @@ test "seal and unseal with buffer" {
     try std.testing.expectEqual(s2_ptr.*.c.*, new_ptr.*.c.*);
 
     try std.testing.expectEqual(s2_ptr.*.e.?.*, new_ptr.*.e.?.*);
+}
+
+test "seal and unseal union with string field with buffer" {
+    const U = union(enum) { a: u64, b: []const u8, c: u32 };
+
+    const buffer_size = 40;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    const u_ptr: *U = try allocator.create(U);
+
+    u_ptr.* = U{ .b = "lorem ipsum" };
+    _ = try seal_into_buffer(*U, u_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    allocator.destroy(u_ptr);
+
+    const new_ptr = try unseal_from_buffer(*U, buffer[0..], allocator);
+    defer {
+        allocator.free(new_ptr.b);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expect(u_ptr != new_ptr);
+    try std.testing.expectEqualStrings("lorem ipsum", new_ptr.b);
+}
+
+const E = enum { a, b, c };
+test "seal and unseal structure with enum field with buffer" {
+    const S = struct {
+        a: E,
+        b: u8,
+    };
+
+    const buffer_size = 2;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var s_ptr = try allocator.create(S);
+
+    s_ptr.a = E.c;
+    s_ptr.b = 201;
+
+    _ = try seal_into_buffer(*S, s_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    allocator.destroy(s_ptr);
+
+    const new_ptr = try unseal_from_buffer(*S, buffer[0..], allocator);
+    defer allocator.destroy(new_ptr);
+
+    try std.testing.expectEqual(E.c, new_ptr.*.a);
+    try std.testing.expectEqual(201, new_ptr.*.b);
+}
+
+test "seal and unseal structure with an optional slice of structures with buffer" {
+    const S1 = struct {
+        a: u32,
+        b: u8,
+    };
+    const S2 = struct { a: u32, b: ?[]const S1 = null };
+
+    const buffer_size = 40;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(S1).init(allocator);
+    defer children.deinit();
+
+    try children.append(S1{
+        .a = 4_294_967_295,
+        .b = 'A',
+    });
+
+    var s2_ptr = try allocator.create(S2);
+
+    s2_ptr.a = 2_147_483_647;
+    s2_ptr.b = try children.toOwnedSlice();
+
+    _ = try seal_into_buffer(*S2, s2_ptr, buffer[0..]);
+
+    const child_ptr = &s2_ptr.b.?[0];
+    // Make sure data exists only in the buffer
+    allocator.free(s2_ptr.b.?);
+    allocator.destroy(s2_ptr);
+
+    const new_ptr = try unseal_from_buffer(*S2, buffer[0..], allocator);
+    defer {
+        allocator.free(new_ptr.b.?);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqual(2_147_483_647, new_ptr.a);
+    try std.testing.expect(child_ptr != &new_ptr.b.?[0]);
+    try std.testing.expectEqual(4_294_967_295, new_ptr.b.?[0].a);
+    try std.testing.expectEqual('A', new_ptr.b.?[0].b);
+}
+
+const R1 = struct {
+    l: []const u8,
+    children: ?[]const R1 = null,
+
+    pub fn deinit(self: *const R1, allocator: std.mem.Allocator) void {
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinit(allocator);
+        }
+
+        allocator.free(children);
+    }
+
+    pub fn deinitDeserialized(self: *const R1, allocator: std.mem.Allocator) void {
+        allocator.free(self.l);
+
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinitDeserialized(allocator);
+        }
+
+        allocator.free(children);
+    }
+};
+test "seal and unseal recursive structure with buffer" {
+    const buffer_size = 240;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(R1).init(allocator);
+    defer children.deinit();
+
+    try children.append(R1{
+        .l = "Leaf 1",
+    });
+    try children.append(R1{
+        .l = "Leaf 2",
+    });
+
+    try children.append(R1{
+        .l = "Branch 1",
+        .children = try children.toOwnedSlice(),
+    });
+
+    try children.append(R1{
+        .l = "Branch 2",
+    });
+
+    var r_ptr: *R1 = try allocator.create(R1);
+
+    r_ptr.l = "Root";
+    r_ptr.children = try children.toOwnedSlice();
+
+    _ = try seal_into_buffer(*R1, r_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    r_ptr.deinit(allocator);
+    allocator.destroy(r_ptr);
+
+    const new_ptr: *R1 = try unseal_from_buffer(*R1, buffer[0..], allocator);
+    defer {
+        new_ptr.deinitDeserialized(allocator);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqualStrings("Root", new_ptr.l);
+
+    try std.testing.expectEqualStrings("Branch 1", new_ptr.children.?[0].l);
+    try std.testing.expectEqualStrings("Leaf 1", new_ptr.children.?[0].children.?[0].l);
+    try std.testing.expectEqualStrings("Leaf 2", new_ptr.children.?[0].children.?[1].l);
+
+    try std.testing.expectEqualStrings("Branch 2", new_ptr.children.?[1].l);
+    try std.testing.expectEqual(null, new_ptr.children.?[1].children);
+}
+
+const R2 = struct {
+    l: []const u8,
+    e: ?E = null,
+    children: ?[]const C = null,
+
+    pub fn deinit(self: *const R2, allocator: std.mem.Allocator) void {
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinit(allocator);
+        }
+
+        allocator.free(children);
+    }
+
+    pub fn deinitDeserialized(self: *const R2, allocator: std.mem.Allocator) void {
+        allocator.free(self.l);
+
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinitDeserialized(allocator);
+        }
+
+        allocator.free(children);
+    }
+};
+
+const C = union(enum) {
+    s: []const u8,
+    r: R2,
+
+    pub fn deinit(self: C, allocator: std.mem.Allocator) void {
+        switch (self) {
+            C.r => self.r.deinit(allocator),
+            else => undefined,
+        }
+    }
+
+    pub fn deinitDeserialized(self: C, allocator: std.mem.Allocator) void {
+        switch (self) {
+            C.r => self.r.deinitDeserialized(allocator),
+            C.s => allocator.free(self.s),
+        }
+    }
+};
+test "seal and unseal complex recursive union with buffer" {
+    const buffer_size = 328;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(C).init(allocator);
+    defer children.deinit();
+
+    try children.append(C{ .s = "Leaf 1" });
+    try children.append(C{ .s = "Leaf 2" });
+
+    try children.append(C{
+        .r = R2{
+            .l = "Branch 1",
+            .e = .a,
+            .children = try children.toOwnedSlice(),
+        },
+    });
+    try children.append(C{
+        .r = R2{
+            .l = "Branch 2",
+            .e = .c,
+        },
+    });
+
+    const c_ptr = try allocator.create(C);
+
+    c_ptr.* = C{
+        .r = R2{
+            .l = "Root",
+            .e = .b,
+            .children = try children.toOwnedSlice(),
+        },
+    };
+
+    _ = try seal_into_buffer(*C, c_ptr, buffer[0..]);
+
+    c_ptr.deinit(allocator);
+    allocator.destroy(c_ptr);
+
+    const new_ptr: *C = try unseal_from_buffer(*C, buffer[0..], allocator);
+    defer {
+        new_ptr.deinitDeserialized(allocator);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqualStrings("Root", new_ptr.r.l);
+    try std.testing.expectEqual(.b, new_ptr.r.e);
+    try std.testing.expectEqualStrings("Branch 1", new_ptr.r.children.?[0].r.l);
+    try std.testing.expectEqual(.a, new_ptr.r.children.?[0].r.e);
+    try std.testing.expectEqualStrings("Leaf 1", new_ptr.r.children.?[0].r.children.?[0].s);
+    try std.testing.expectEqualStrings("Leaf 2", new_ptr.r.children.?[0].r.children.?[1].s);
+    try std.testing.expectEqualStrings("Branch 2", new_ptr.r.children.?[1].r.l);
+    try std.testing.expectEqual(.c, new_ptr.r.children.?[1].r.e);
 }


### PR DESCRIPTION
This commit will enable serializing and deserializing nested structures by fixing how variant_ptr gets initialized.

I also added new test cases to ensure all my use cases would be covered by this library:
- compact union with string field
- seal and unseal with buffer:
   - union with string field
   - structure with enum field
   - structure with an optional slice of structures
   - recursive structure
   - complex recursive union

And renamed `value` to `value_ptr` across the `repair` function and updated related references to imporve reasoning about the value.