### PR TITLE
ci(workflow): add CI for Zig 0.13.0 on Ubuntu and macOS

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -1,0 +1,20 @@
+name: Works with Zig 0.13.0
+on:
+  push:
+    branches:
+      - '**'
+  pull_request: {}
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
+      - run: zig fmt --check *.zig src/*.zig
+      - run: zig build test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/DomKalinowski/zig_sealed_and_compact/actions/workflows/validate-and-test.yml/badge.svg)
+
 # Zig Seal/Unseal and Compact
 
 This repository contains an implementation of two concepts in Zig:
@@ -98,3 +100,9 @@ I seem to recall that the idea was that you did not have to modify the memory on
 I think the library I was thinking of was this: https://hackage.haskell.org/package/compact, although rereading it they were actually working on something
 a bit different.
 
+## Workflow
+
+When working on the library consider using `watchexec` to automaticaly re-run tests on save:
+```
+watchexec -c -e zig zig build test --verbose
+```


### PR DESCRIPTION
Introduces a GitHub Actions workflow to validate and test the project using Zig version 0.13.0. The workflow triggers on all branch pushes and pull requests, running on both Ubuntu and macOS. It includes steps for checking code formatting and running tests.

Additionally, updates README to include build status badge and instructions for using `watchexec` to automatically re-run tests during development.