### PR TITLE
refactor(main): change imports to public constants

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,8 +1,7 @@
 const std = @import("std");
-const testing = std.testing;
 
-const compact = @import("compact.zig");
-const seal = @import("seal.zig");
+pub const compact = @import("compact.zig");
+pub const seal = @import("seal.zig");
 
 test "full test set" {
     _ = @import("compact.zig");


### PR DESCRIPTION
Changed `compact` and `seal` imports in main.zig to public constants. This adjustment allows these constants to be accessed when imported in the consumer application.